### PR TITLE
feature #19205 [HttpKernel] Allow bundles to declare classes and anno…

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
+use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+
+/**
+ * Warms up XML and YAML serializer metadata.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class SerializerCacheWarmer implements CacheWarmerInterface
+{
+    private $loader;
+    private $phpArrayFile;
+    private $fallbackPool;
+
+    /**
+     * @param LoaderChain            $loader
+     * @param string                 $phpArrayFile The PHP file where metadata are cached.
+     * @param CacheItemPoolInterface $fallbackPool The pool where runtime-discovered metadata are cached.
+     */
+    public function __construct(LoaderChain $loader, $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    {
+        $this->loader = $loader;
+        $this->phpArrayFile = $phpArrayFile;
+        if (!$fallbackPool instanceof AdapterInterface) {
+            $fallbackPool = new ProxyAdapter($fallbackPool);
+        }
+        $this->fallbackPool = $fallbackPool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $adapter = new PhpArrayAdapter($this->phpArrayFile, $this->fallbackPool);
+        $arrayPool = new ArrayAdapter(0, false);
+
+        $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory($this->loader), $arrayPool);
+
+        foreach ($this->extractSupportedLoaders(array($this->loader)) as $loader) {
+            foreach ($loader->getMappedClasses() as $mappedClass) {
+                $metadataFactory->getMetadataFor($mappedClass);
+            }
+        }
+
+        $values = $arrayPool->getValues();
+        $adapter->warmUp($values);
+
+        foreach ($values as $k => $v) {
+            $item = $this->fallbackPool->getItem($k);
+            $this->fallbackPool->saveDeferred($item->set($v));
+        }
+        $this->fallbackPool->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * @param LoaderInterface[] $loaders
+     *
+     * @return XmlFileLoader[]|YamlFileLoader[]
+     */
+    private function extractSupportedLoaders(array $loaders)
+    {
+        $supportedLoaders = array();
+
+        foreach ($loaders as $loader) {
+            if ($loader instanceof XmlFileLoader || $loader instanceof YamlFileLoader) {
+                $supportedLoaders[] = $loader;
+            } elseif ($loader instanceof LoaderChain) {
+                $supportedLoaders = array_merge($supportedLoaders, $this->extractSupportedLoaders($loader->getDelegatedLoaders()));
+            }
+        }
+
+        return $supportedLoaders;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="serializer.mapping.cache.prefix" />
+        <parameter key="serializer.mapping.cache.file">%kernel.cache_dir%/serialization.php</parameter>
     </parameters>
 
     <services>
@@ -33,12 +34,32 @@
         </service>
 
         <!-- Class Metadata Factory -->
-        <service id="serializer.mapping.class_metadata_factory" class="Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory" public="false">
+        <service id="serializer.mapping.raw_class_metadata_factory" class="Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory" public="false">
             <argument type="service" id="serializer.mapping.chain_loader" />
             <argument>null</argument>
         </service>
 
+        <service id="serializer.mapping.cache_class_metadata_factory" class="Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory" public="false">
+            <argument type="service" id="serializer.mapping.raw_class_metadata_factory" />
+            <argument /><!-- Cache pool populated by the extension -->
+        </service>
+
+        <service id="serializer.mapping.class_metadata_factory" alias="serializer.mapping.raw_class_metadata_factory" />
+
         <!-- Cache -->
+        <service id="serializer.mapping.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer" public="false">
+            <argument type="service" id="serializer.mapping.chain_loader" />
+            <argument>%serializer.mapping.cache.file%</argument>
+            <argument type="service" id="cache.serializer" />
+            <tag name="kernel.cache_warmer" />
+        </service>
+
+        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">
+            <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
+            <argument>%serializer.mapping.cache.file%</argument>
+            <argument type="service" id="cache.serializer" />
+        </service>
+
         <service id="serializer.mapping.cache.doctrine.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializationCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializationCacheWarmerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
+use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+
+class SerializationCacheWarmerTest extends TestCase
+{
+    public function testWarmUp()
+    {
+        $loader = new LoaderChain(array(
+            new XmlFileLoader(__DIR__.'/../Fixtures/Serialization/Resources/person.xml'),
+            new YamlFileLoader(__DIR__.'/../Fixtures/Serialization/Resources/author.yml'),
+        ));
+
+        $file = sys_get_temp_dir().'/cache-serializer.php';
+        @unlink($file);
+
+        $fallbackPool = new ArrayAdapter();
+
+        $warmer = new SerializerCacheWarmer($loader, $file, $fallbackPool);
+        $warmer->warmUp(dirname($file));
+
+        $this->assertFileExists($file);
+
+        $values = require $file;
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(3, $values); // 2 classes + Doctrine namespace
+        $this->assertArrayHasKey('%5BSymfony%5CBundle%5CFrameworkBundle%5CTests%5CFixtures%5CSerialization%5CPerson%5D%5B1%5D', $values);
+        $this->assertArrayHasKey('%5BSymfony%5CBundle%5CFrameworkBundle%5CTests%5CFixtures%5CSerialization%5CAuthor%5D%5B1%5D', $values);
+
+        $values = $fallbackPool->getValues();
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(3, $values); // 2 classes + Doctrine namespace
+        $this->assertArrayHasKey('%5BSymfony%5CBundle%5CFrameworkBundle%5CTests%5CFixtures%5CSerialization%5CPerson%5D%5B1%5D', $values);
+        $this->assertArrayHasKey('%5BSymfony%5CBundle%5CFrameworkBundle%5CTests%5CFixtures%5CSerialization%5CAuthor%5D%5B1%5D', $values);
+    }
+
+    public function testWarmUpWithoutLoader()
+    {
+        $file = sys_get_temp_dir().'/cache-serializer-without-loader.php';
+        @unlink($file);
+
+        $fallbackPool = new ArrayAdapter();
+
+        $warmer = new SerializerCacheWarmer(new LoaderChain(array()), $file, $fallbackPool);
+        $warmer->warmUp(dirname($file));
+
+        $this->assertFileExists($file);
+
+        $values = require $file;
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(0, $values);
+
+        $values = $fallbackPool->getValues();
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(0, $values);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Author.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Author.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization;
+
+class Author
+{
+    public $gender;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Person.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Person.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization;
+
+class Person
+{
+    public $gender;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/author.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/author.yml
@@ -1,0 +1,4 @@
+Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization\Author:
+    attributes:
+        gender:
+            groups: ['group1', 'group2']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/person.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/person.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+        http://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+>
+    <class name="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization\Person">
+        <attribute name="gender">
+            <group>group1</group>
+            <group>group2</group>
+        </attribute>
+    </class>
+</serializer>

--- a/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
@@ -63,4 +63,12 @@ class LoaderChain implements LoaderInterface
 
         return $success;
     }
+
+    /**
+     * @return LoaderInterface[]
+     */
+    public function getDelegatedLoaders()
+    {
+        return $this->loaders;
+    }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -36,12 +36,7 @@ class XmlFileLoader extends FileLoader
     public function loadClassMetadata(ClassMetadataInterface $classMetadata)
     {
         if (null === $this->classes) {
-            $this->classes = array();
-            $xml = $this->parseFile($this->file);
-
-            foreach ($xml->class as $class) {
-                $this->classes[(string) $class['name']] = $class;
-            }
+            $this->classes = $this->loadClassesFromXml();
         }
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -75,6 +70,16 @@ class XmlFileLoader extends FileLoader
     }
 
     /**
+     * Return the names of the classes mapped in this file.
+     *
+     * @return string[] The classes names
+     */
+    public function getMappedClasses()
+    {
+        return array_keys($this->loadClassesFromXml());
+    }
+
+    /**
      * Parses a XML File.
      *
      * @param string $file Path of file
@@ -92,5 +97,17 @@ class XmlFileLoader extends FileLoader
         }
 
         return simplexml_import_dom($dom);
+    }
+
+    private function loadClassesFromXml()
+    {
+        $xml = $this->parseFile($this->file);
+        $classes = array();
+
+        foreach ($xml->class as $class) {
+            $classes[(string) $class['name']] = $class;
+        }
+
+        return $classes;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -38,26 +38,7 @@ class YamlFileLoader extends FileLoader
     public function loadClassMetadata(ClassMetadataInterface $classMetadata)
     {
         if (null === $this->classes) {
-            if (!stream_is_local($this->file)) {
-                throw new MappingException(sprintf('This is not a local file "%s".', $this->file));
-            }
-
-            if (null === $this->yamlParser) {
-                $this->yamlParser = new Parser();
-            }
-
-            $classes = $this->yamlParser->parse(file_get_contents($this->file));
-
-            if (empty($classes)) {
-                return false;
-            }
-
-            // not an array
-            if (!is_array($classes)) {
-                throw new MappingException(sprintf('The file "%s" must contain a YAML array.', $this->file));
-            }
-
-            $this->classes = $classes;
+            $this->classes = $this->loadClassesFromYaml();
         }
 
         if (isset($this->classes[$classMetadata->getName()])) {
@@ -102,5 +83,39 @@ class YamlFileLoader extends FileLoader
         }
 
         return false;
+    }
+
+    /**
+     * Return the names of the classes mapped in this file.
+     *
+     * @return string[] The classes names
+     */
+    public function getMappedClasses()
+    {
+        return array_keys($this->loadClassesFromYaml());
+    }
+
+    private function loadClassesFromYaml()
+    {
+        if (!stream_is_local($this->file)) {
+            throw new MappingException(sprintf('This is not a local file "%s".', $this->file));
+        }
+
+        if (null === $this->yamlParser) {
+            $this->yamlParser = new Parser();
+        }
+
+        $classes = $this->yamlParser->parse(file_get_contents($this->file));
+
+        if (empty($classes)) {
+            return false;
+        }
+
+        // not an array
+        if (!is_array($classes)) {
+            throw new MappingException(sprintf('The file "%s" must contain a YAML array.', $this->file));
+        }
+
+        return $classes;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 2.7, 2.8, 3.0 or 3.1 for fixes |
| Bug fix? | yes/no |
| New feature? | yes/no |
| BC breaks? | yes/no |
| Deprecations? | yes/no |
| Tests pass? | yes/no |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

…tated classes to compile using patterns (tgalopin)

This PR was merged into the 3.2-dev branch.
## Discussion

[HttpKernel] Allow bundles to declare classes and annotated classes to compile using patterns

| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR introduces a simple system of patterns based on wildcards for classes to cache in the HttpKernel dependency injections extensions. This system started to be implemented in https://github.com/symfony/symfony/pull/18533 but I split it up here to use it also in the classes to compile.
## Commits

1be7424 [HttpKernel] Allow usage of patterns in classes and annotations to cache
